### PR TITLE
Resolve "Automatic type inference for model classes"

### DIFF
--- a/packages/mix-models/src/mix.ts
+++ b/packages/mix-models/src/mix.ts
@@ -1,6 +1,9 @@
-import { Constructor } from './model';
+import { BaseModel, Constructor } from './model';
 
-export function mix<T extends object, TBase extends Constructor<T>>(root: TBase, ...mixins: ((parent: TBase) => TBase)[]) {
+export function mix<D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(
+  root: C,
+  ...mixins: ((parent: C) => any)[]
+) {
   let result = root;
 
   for (const mixin of mixins) {

--- a/packages/mix-models/src/mix.ts
+++ b/packages/mix-models/src/mix.ts
@@ -2,7 +2,7 @@ import { BaseModel, Constructor } from './model';
 
 export function mix<D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(
   root: C,
-  ...mixins: ((parent: C) => any)[]
+  ...mixins: ((parent: C) => C)[]
 ) {
   let result = root;
 

--- a/packages/mix-models/src/model.ts
+++ b/packages/mix-models/src/model.ts
@@ -46,7 +46,7 @@ let globalUidCounter = 0n;
 
 const unmix = () => undefined;
 
-export class BaseModel<T extends object> {
+export abstract class BaseModel<T extends object> {
   readonly uid: string;
 
   readonly _flags: ModelFlags;

--- a/packages/mix-models/src/model.ts
+++ b/packages/mix-models/src/model.ts
@@ -33,7 +33,9 @@ export interface Base<T extends object> {
   hasMixin(mixin: Function): boolean;
 }
 
-export type Constructor<T extends object> = new (...args: any[]) => BaseModel<T>;
+export type Constructor<D extends object, T extends BaseModel<D> = BaseModel<D>> = T extends BaseModel<D>
+  ? new (...args: any[]) => T
+  : never;
 
 /**
  * Global uid counter.
@@ -44,7 +46,7 @@ let globalUidCounter = 0n;
 
 const unmix = () => undefined;
 
-export abstract class BaseModel<T extends object> {
+export class BaseModel<T extends object> {
   readonly uid: string;
 
   readonly _flags: ModelFlags;

--- a/packages/mix-models/src/rollback/mixin.ts
+++ b/packages/mix-models/src/rollback/mixin.ts
@@ -118,3 +118,8 @@ export function rollbackMixin<D extends object, T extends BaseModel<D>, C extend
 export function mixRollback<D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(initialMask?: RollbackMask) {
   return (parent: C) => rollbackMixin<D, T, C>(parent, initialMask);
 }
+
+export function mixRollback2(initialMask?: RollbackMask) {
+  return <D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(parent: C) =>
+    rollbackMixin<D, T, C>(parent, initialMask);
+}

--- a/packages/mix-models/src/rollback/mixin.ts
+++ b/packages/mix-models/src/rollback/mixin.ts
@@ -2,7 +2,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import set from 'lodash/set';
 
-import { Constructor } from '../model';
+import { Constructor, BaseModel } from '../model';
 import { RollbackMask } from './interfaces';
 import { flattenKeys } from './flatten-keys';
 
@@ -20,96 +20,101 @@ export interface RollbackPrivate<T extends object> extends Rollback {
   recursivePathFinder(mask: string[], arrayPosition: number, path?: string): void;
 }
 
-export function mixRollback<T extends object, TBase extends Constructor<T>>(initialMask?: RollbackMask) {
-  return function(parent: TBase) {
-    return class extends parent implements RollbackPrivate<T> {
-      _original: T;
-      _maskPaths?: string[] = initialMask ? flattenKeys(initialMask) : undefined;
+export function rollbackMixin<D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(
+  parent: C,
+  initialMask?: RollbackMask
+) {
+  return class extends parent implements RollbackPrivate<D> {
+    _original: D;
+    _maskPaths?: string[] = initialMask ? flattenKeys(initialMask) : undefined;
 
-      constructor(...args: any[]) {
-        super(...args);
-        this._original = cloneDeep(args[1]);
-      }
+    constructor(...args: any[]) {
+      super(...args);
+      this._original = cloneDeep(args[1]);
+    }
 
-      updateOriginal() {
-        this._original = cloneDeep(this._internal.data) as T;
-      }
+    updateOriginal() {
+      this._original = cloneDeep(this._internal.data);
+    }
 
-      afterCreate() {
-        this.updateOriginal();
-        super.afterCreate();
-      }
+    afterCreate() {
+      this.updateOriginal();
+      super.afterCreate();
+    }
 
-      afterSave() {
-        this.updateOriginal();
-        super.afterSave();
-      }
+    afterSave() {
+      this.updateOriginal();
+      super.afterSave();
+    }
 
-      rollback(customMask?: RollbackMask) {
-        if (!this.dirty) return;
+    rollback(customMask?: RollbackMask) {
+      if (!this.dirty) return;
 
-        this.beforeRollback();
+      this.beforeRollback();
 
-        this._flags.locked = true;
+      this._flags.locked = true;
 
-        if (customMask || this._maskPaths) {
-          const maskArray = customMask ? flattenKeys(customMask) : (this._maskPaths as string[]);
+      if (customMask || this._maskPaths) {
+        const maskArray = customMask ? flattenKeys(customMask) : (this._maskPaths as string[]);
 
-          for (const mask of maskArray) {
-            const temp = mask.split('.');
-            const pos = temp.findIndex(val => val === '[]');
+        for (const mask of maskArray) {
+          const temp = mask.split('.');
+          const pos = temp.findIndex(val => val === '[]');
 
-            if (pos > -1) {
-              const paths = this.recursivePathFinder(temp, pos);
+          if (pos > -1) {
+            const paths = this.recursivePathFinder(temp, pos);
 
-              for (const path of paths) {
-                set(this._internal.data, path, cloneDeep(get(this._original, path)));
-              }
-            } else {
-              set(this._internal.data, mask, cloneDeep(get(this._original, mask)));
+            for (const path of paths) {
+              set(this._internal.data, path, cloneDeep(get(this._original, path)));
             }
-          }
-        } else {
-          for (const key in this._original) this._internal.data[key] = cloneDeep(this._original[key]);
-        }
-
-        this._flags.dirty = false;
-        this._flags.locked = false;
-
-        this.afterRollback();
-      }
-
-      hasMixin(mixin: Function): boolean {
-        return mixin === mixRollback || super.hasMixin(mixin);
-      }
-
-      recursivePathFinder(mask: string[], arrayPosition: number, path = ''): string[] {
-        const result: string[] = [];
-
-        if (arrayPosition > -1) {
-          path += mask.slice(0, arrayPosition).join('.');
-
-          const el = get(this._internal.data, path);
-
-          if (!Array.isArray(el)) return result;
-
-          const localMask = mask.slice(arrayPosition + 1);
-          const pos = localMask.findIndex(val => val === '[]');
-          const suffix = localMask.join('.');
-
-          for (let i = 0; i < el.length; i++) {
-            const localPath = `${path}.[${i}].`;
-
-            if (pos > -1) {
-              result.push(...this.recursivePathFinder(localMask, pos, localPath));
-            } else {
-              result.push(`${localPath}${suffix}`);
-            }
+          } else {
+            set(this._internal.data, mask, cloneDeep(get(this._original, mask)));
           }
         }
-
-        return result;
+      } else {
+        for (const key in this._original) this._internal.data[key] = cloneDeep(this._original[key]);
       }
-    };
+
+      this._flags.dirty = false;
+      this._flags.locked = false;
+
+      this.afterRollback();
+    }
+
+    hasMixin(mixin: Function): boolean {
+      return mixin === mixRollback || super.hasMixin(mixin);
+    }
+
+    recursivePathFinder(mask: string[], arrayPosition: number, path = ''): string[] {
+      const result: string[] = [];
+
+      if (arrayPosition > -1) {
+        path += mask.slice(0, arrayPosition).join('.');
+
+        const el = get(this._internal.data, path);
+
+        if (!Array.isArray(el)) return result;
+
+        const localMask = mask.slice(arrayPosition + 1);
+        const pos = localMask.findIndex(val => val === '[]');
+        const suffix = localMask.join('.');
+
+        for (let i = 0; i < el.length; i++) {
+          const localPath = `${path}.[${i}].`;
+
+          if (pos > -1) {
+            result.push(...this.recursivePathFinder(localMask, pos, localPath));
+          } else {
+            result.push(`${localPath}${suffix}`);
+          }
+        }
+      }
+
+      return result;
+    }
   };
+}
+
+export function mixRollback<D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(initialMask?: RollbackMask) {
+  return (parent: C) => rollbackMixin<D, T, C>(parent, initialMask);
 }

--- a/packages/mix-models/src/save.ts
+++ b/packages/mix-models/src/save.ts
@@ -156,3 +156,7 @@ export function saveMixin<D extends object, T extends BaseModel<D>, C extends Co
 export function mixSave<D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>() {
   return (parent: C) => saveMixin<D, T, C>(parent);
 }
+
+export function mixSave2() {
+  return <D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(parent: C) => saveMixin<D, T, C>(parent);
+}

--- a/packages/mix-models/src/validate/mixin.ts
+++ b/packages/mix-models/src/validate/mixin.ts
@@ -200,3 +200,8 @@ export function mixValidate<
 >(pattern?: Pattern) {
   return (parent: C) => validateMixin<D, T, C, U>(parent, pattern);
 }
+
+export function mixValidate2<U extends ValidationBase = ValidationBase>(pattern?: Pattern) {
+  return <D extends object, T extends BaseModel<D>, C extends Constructor<D, T>>(parent: C) =>
+    validateMixin<D, T, C, U>(parent, pattern);
+}

--- a/packages/mix-models/src/validate/mixin.ts
+++ b/packages/mix-models/src/validate/mixin.ts
@@ -3,8 +3,8 @@ import { reactive, computed } from 'vue-demi';
 
 import { Options, Constructor } from '../model';
 
-import { Pattern, AnyPattern, ObjectPattern, asPattern, isArrayPatternUnsafe } from './interfaces';
-import { Children, Validation, ValidationBase } from './validation';
+import { ValidationBase, Pattern, AnyPattern, ObjectPattern, asPattern, isArrayPatternUnsafe } from './interfaces';
+import { Children, Validation } from './validation';
 import { Provider } from './provider';
 
 export interface ValidateOptions extends Options {

--- a/packages/mix-models/src/validate/validation.ts
+++ b/packages/mix-models/src/validate/validation.ts
@@ -1,7 +1,7 @@
 import { WatchStopHandle, ComputedRef, computed, reactive, watch } from 'vue-demi';
 import get from 'lodash/get';
 
-import { ValidationRule } from './interfaces';
+import { ValidationRule, ValidationBase } from './interfaces';
 import { Provider } from './provider';
 
 export type Children = Record<string, ValidationBase> | ValidationBase[];
@@ -48,25 +48,6 @@ export interface Props {
   selfInvalid: boolean;
   selfDirty: boolean;
   message: string;
-}
-
-export interface ValidationBase {
-  readonly children?: Children;
-  readonly anyChildDirty: boolean;
-  readonly selfDirty: boolean;
-  readonly dirty: boolean;
-  readonly anyChildInvalid: boolean;
-  readonly selfInvalid: boolean;
-  readonly invalid: boolean;
-  readonly message: string;
-  readonly dirtyMessage: string;
-  readonly c?: unknown;
-
-  touch(): void;
-  reset(): void;
-  updatePath(index: number, section: string): void;
-  checkValue(someValue: unknown): boolean;
-  destroy(): void;
 }
 
 export class Validation implements ValidationBase {

--- a/packages/mix-models/tests/__mocks__/conditional-model.ts
+++ b/packages/mix-models/tests/__mocks__/conditional-model.ts
@@ -12,7 +12,7 @@ export const validations = {
   name: (v: string) => nameRegex.test(v) || 'invalid name',
   email: (v: string, data: unknown, path: string[]) =>
     !!get(data, [...path.slice(0, path.length - 1), 'name'].join('.')) || (v.length > 0 && emailRegex.test(v)) || 'invalid e-mail'
-};
+} as const;
 
 export interface Validations extends ValidationBase {
   readonly c: {
@@ -27,7 +27,7 @@ export type ModelType = Base<Data> & Validate<Validations>;
 
 export interface Model extends DataModel, ValidatePrivate<Validations> {}
 
-export class Model extends mix<Data, typeof DataModel>(DataModel, mixValidate<Data, typeof DataModel, Validations>(validations)) {
+export class Model extends mix<Data, DataModel, typeof DataModel>(DataModel, mixValidate(validations)) {
   constructor(initialData?: Data, react = true) {
     super('', initialData ?? { name: '', email: '' }, react);
   }

--- a/packages/mix-models/tests/__mocks__/credentials-model.ts
+++ b/packages/mix-models/tests/__mocks__/credentials-model.ts
@@ -1,0 +1,49 @@
+import {
+  Base,
+  BaseModel,
+  PatternAssert,
+  RollbackPrivate,
+  mixRollback,
+  Rollback,
+  ValidatePrivate,
+  Validate,
+  mixValidate,
+  mix,
+  Options
+} from '@vueent/mix-models';
+
+import { phoneRegex } from './regular-expressions';
+
+export interface Data {
+  first: string;
+  second: string;
+  last: string;
+}
+
+export class DataModel extends BaseModel<Data> {}
+
+export const validations = {
+  first: (v: string) => v.length > 0 || 'invalid first name',
+  second: (v: string) => v.length > 0 || 'invalid second name',
+  last: (v: string) => v.length > 0 || 'invalid last name'
+};
+
+export type Validations = PatternAssert<typeof validations, Data>;
+
+export type ModelType = Base<Data> & Rollback & Validate<Validations>;
+
+export interface Model<ModelOptions extends Options> extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
+
+export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(
+  DataModel,
+  mixRollback(),
+  mixValidate<Data, typeof DataModel, Validations>(validations)
+) {
+  constructor(initialData?: Data, react = true, ...options: ModelOptions[]) {
+    super('id', initialData ?? { first: '', second: '', last: '' }, react, ...options);
+  }
+}
+
+export function create<ModelOptions extends Options>(basicData?: Data, react = true, ...options: ModelOptions[]): ModelType {
+  return new Model(basicData, react, ...options);
+}

--- a/packages/mix-models/tests/__mocks__/credentials-model.ts
+++ b/packages/mix-models/tests/__mocks__/credentials-model.ts
@@ -24,7 +24,7 @@ export const validations = {
   first: (v: string) => v.length > 0 || 'invalid first name',
   second: (v: string) => v.length > 0 || 'invalid second name',
   last: (v: string) => v.length > 0 || 'invalid last name'
-};
+} as const;
 
 export type Validations = PatternAssert<typeof validations, Data>;
 
@@ -32,10 +32,10 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model<ModelOptions extends Options> extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(
+export class Model<ModelOptions extends Options> extends mix<Data, DataModel, typeof DataModel>(
   DataModel,
   mixRollback(),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
+  mixValidate(validations)
 ) {
   constructor(initialData?: Data, react = true, ...options: ModelOptions[]) {
     super('id', initialData ?? { first: '', second: '', last: '' }, react, ...options);

--- a/packages/mix-models/tests/__mocks__/credentials-model.ts
+++ b/packages/mix-models/tests/__mocks__/credentials-model.ts
@@ -12,8 +12,6 @@ import {
   Options
 } from '@vueent/mix-models';
 
-import { phoneRegex } from './regular-expressions';
-
 export interface Data {
   first: string;
   second: string;

--- a/packages/mix-models/tests/__mocks__/data-model.ts
+++ b/packages/mix-models/tests/__mocks__/data-model.ts
@@ -25,7 +25,7 @@ export type ModelType = Base<Data> & Rollback & Save;
 
 export interface Model extends DataModel, RollbackPrivate<Data>, SavePrivate<Data> {}
 
-export class Model extends mix<Data, typeof DataModel>(DataModel, mixRollback(), mixSave()) {
+export class Model extends mix<Data, DataModel, typeof DataModel>(DataModel, mixRollback(), mixSave()) {
   constructor(initialData?: Data, react = true, saveOptions?: SaveOptions<Data>) {
     super('name', initialData ?? { name: '', official: { first: '', last: '' } }, react, saveOptions);
   }

--- a/packages/mix-models/tests/__mocks__/deep-array-model.ts
+++ b/packages/mix-models/tests/__mocks__/deep-array-model.ts
@@ -1,7 +1,6 @@
 import {
   Base,
   BaseModel,
-  Pattern,
   ValidationBase,
   RollbackPrivate,
   mixRollback,
@@ -29,15 +28,15 @@ export class DataModel extends BaseModel<Data> {}
 export const rollbackMask = {
   id: true,
   phones: { $array: true, number: true }
-};
+} as const;
 
-export const validations: Pattern = {
+export const validations = {
   id: (v?: string) => (v !== undefined && v.length > 0) || 'invalid id',
   phones: {
     $each: (v?: string) => (v !== undefined && phoneRegex.test(v)) || 'invalid phone',
     $self: (v: unknown) => (Array.isArray(v) && v.length > 0) || 'invalid phones'
   }
-};
+} as const;
 
 export interface PhonesValidation extends ValidationBase {
   readonly c: ValidationBase[];
@@ -54,10 +53,10 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model<ModelOptions extends Options> extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(
+export class Model<ModelOptions extends Options> extends mix<Data, DataModel, typeof DataModel>(
   DataModel,
   mixRollback(rollbackMask),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
+  mixValidate(validations)
 ) {
   constructor(initialData?: Data, react = true, ...options: ModelOptions[]) {
     super('id', initialData ?? { id: undefined, phones: [], items: [] }, react, ...options);

--- a/packages/mix-models/tests/__mocks__/deep-model.ts
+++ b/packages/mix-models/tests/__mocks__/deep-model.ts
@@ -1,7 +1,6 @@
 import {
   Base,
   BaseModel,
-  Pattern,
   ValidationBase,
   RollbackPrivate,
   mixRollback,
@@ -39,9 +38,9 @@ export const rollbackMask = {
   email: true,
   human: true,
   phones: true
-};
+} as const;
 
-export const validations: Pattern = {
+export const validations = {
   id: (v: unknown) => v === undefined || typeof v === 'number' || 'invalid id',
   email: (v?: string) => (v !== undefined && v.length > 0 && emailRegex.test(v)) || 'invalid e-mail',
   human: {
@@ -58,7 +57,7 @@ export const validations: Pattern = {
     },
     $self: (v: unknown) => (Array.isArray(v) && v.length > 0) || 'invalid phones'
   }
-};
+} as const;
 
 export interface HumanValidation extends ValidationBase {
   readonly c: {
@@ -91,10 +90,10 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model<ModelOptions extends Options> extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(
+export class Model<ModelOptions extends Options> extends mix<Data, DataModel, typeof DataModel>(
   DataModel,
   mixRollback(rollbackMask),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
+  mixValidate(validations)
 ) {
   constructor(initialData?: Data, react = true, ...options: ModelOptions[]) {
     super(

--- a/packages/mix-models/tests/__mocks__/hard-model.ts
+++ b/packages/mix-models/tests/__mocks__/hard-model.ts
@@ -17,8 +17,9 @@ import { phoneRegex } from './regular-expressions';
 export interface Data {
   id: string;
   phones?: string[];
-  credentials: Credentials;
-  documents: Document[];
+  phone?: string;
+  credentials?: Credentials;
+  documents?: Document[];
   items: Item[];
 }
 
@@ -48,6 +49,7 @@ export const validations = {
     $each: (v?: string) => (v !== undefined && phoneRegex.test(v)) || 'invalid phone',
     $self: (v: unknown) => (Array.isArray(v) && v.length > 0) || 'invalid phones'
   },
+  phone: (v?: string) => (v !== undefined && v.length > 0) || 'invalid id',
   credentials: {
     $sub: {
       first: (v: string) => v.length > 0 || 'invalid first name',
@@ -72,7 +74,7 @@ export const validations = {
   }
 };
 
-export type Validations = PatternAssert<typeof validations>;
+export type Validations = PatternAssert<typeof validations, Data>;
 
 export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 

--- a/packages/mix-models/tests/__mocks__/hard-model.ts
+++ b/packages/mix-models/tests/__mocks__/hard-model.ts
@@ -17,14 +17,15 @@ import { phoneRegex } from './regular-expressions';
 export interface Data {
   id: string;
   phones?: string[];
-  credentials: Credentials;
-  documents: Document[];
+  phone?: string;
+  credentials?: Credentials;
+  documents?: Document[];
   items: Item[];
 }
 
 export interface Document {
   id: string;
-  filename: string;
+  filename?: string;
 }
 
 export interface Item {
@@ -48,6 +49,7 @@ export const validations = {
     $each: (v?: string) => (v !== undefined && phoneRegex.test(v)) || 'invalid phone',
     $self: (v: unknown) => (Array.isArray(v) && v.length > 0) || 'invalid phones'
   },
+  phone: (v?: string) => (v !== undefined && v.length > 0) || 'invalid id',
   credentials: {
     $sub: {
       first: (v: string) => v.length > 0 || 'invalid first name',
@@ -72,7 +74,7 @@ export const validations = {
   }
 };
 
-export type Validations = PatternAssert<typeof validations>;
+export type Validations = PatternAssert<typeof validations, Data>;
 
 export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 

--- a/packages/mix-models/tests/__mocks__/hard-model.ts
+++ b/packages/mix-models/tests/__mocks__/hard-model.ts
@@ -1,8 +1,7 @@
 import {
   Base,
   BaseModel,
-  Pattern,
-  ValidationBase,
+  PatternAssert,
   RollbackPrivate,
   mixRollback,
   Rollback,
@@ -43,7 +42,7 @@ export interface Credentials {
 
 export class DataModel extends BaseModel<Data> {}
 
-export const validations: Pattern = {
+export const validations = {
   id: (v: string) => v.length > 0 || 'invalid id',
   phones: {
     $each: (v?: string) => (v !== undefined && phoneRegex.test(v)) || 'invalid phone',
@@ -73,58 +72,7 @@ export const validations: Pattern = {
   }
 };
 
-export interface PhonesValidation extends ValidationBase {
-  readonly c: ValidationBase[];
-}
-
-export interface CredentialsValidation extends ValidationBase {
-  readonly c: {
-    first: ValidationBase;
-    second: ValidationBase;
-    last: ValidationBase;
-  };
-}
-
-export interface DocumentsValidation extends ValidationBase {
-  readonly c: DocumentValidation[];
-}
-
-export interface DocumentValidation extends ValidationBase {
-  readonly c: {
-    id: ValidationBase;
-    filename: ValidationBase;
-  };
-}
-
-export interface ValueValidation extends ValidationBase {
-  readonly c: {
-    val: ValidationBase;
-  };
-}
-
-export interface ValuesValidation extends ValidationBase {
-  readonly c: ValueValidation[];
-}
-
-export interface ItemValidation extends ValidationBase {
-  readonly c: {
-    value: ValuesValidation;
-  };
-}
-
-export interface ItemsValidation extends ValidationBase {
-  readonly c: ItemValidation[];
-}
-
-export interface Validations extends ValidationBase {
-  readonly c: {
-    id: ValidationBase;
-    phones: PhonesValidation;
-    credentials: CredentialsValidation;
-    documents: DocumentsValidation;
-    items: ItemsValidation;
-  };
-}
+export type Validations = PatternAssert<typeof validations>;
 
 export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 

--- a/packages/mix-models/tests/__mocks__/hard-model.ts
+++ b/packages/mix-models/tests/__mocks__/hard-model.ts
@@ -12,13 +12,15 @@ import {
   Options
 } from '@vueent/mix-models';
 
+import { Data as Credentials } from './credentials-model';
+
 import { phoneRegex } from './regular-expressions';
 
 export interface Data {
   id: string;
   phones?: string[];
   phone?: string;
-  credentials?: Credentials;
+  credentials: Credentials;
   documents?: Document[];
   items: Item[];
 }
@@ -33,12 +35,6 @@ export interface Item {
 }
 export interface Value {
   val: string;
-}
-
-export interface Credentials {
-  first: string;
-  second: string;
-  last: string;
 }
 
 export class DataModel extends BaseModel<Data> {}

--- a/packages/mix-models/tests/__mocks__/hard-model.ts
+++ b/packages/mix-models/tests/__mocks__/hard-model.ts
@@ -68,7 +68,7 @@ export const validations = {
       }
     }
   }
-};
+} as const;
 
 export type Validations = PatternAssert<typeof validations, Data>;
 
@@ -76,10 +76,10 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model<ModelOptions extends Options> extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(
+export class Model<ModelOptions extends Options> extends mix<Data, DataModel, typeof DataModel>(
   DataModel,
   mixRollback(),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
+  mixValidate(validations)
 ) {
   constructor(initialData?: Data, react = true, ...options: ModelOptions[]) {
     super(

--- a/packages/mix-models/tests/__mocks__/recursive-model.ts
+++ b/packages/mix-models/tests/__mocks__/recursive-model.ts
@@ -8,7 +8,6 @@ import {
   ValidatePrivate,
   mixValidate,
   ValidationBase,
-  Pattern,
   mix
 } from '@vueent/mix-models';
 
@@ -17,9 +16,16 @@ export interface Data {
   items: Data[];
 }
 
-export const validations: Pattern = {
-  name: (v: any) => ((v as string).length > 0 && (v as string).length < 255 ? true : 'Unexpected name length')
+type ValidationsPattern = {
+  name: (v: any) => boolean | string;
+  items: {
+    $each: ValidationsPattern;
+  };
 };
+
+export const validations = {
+  name: (v: any) => ((v as string).length > 0 && (v as string).length < 255 ? true : 'Unexpected name length')
+} as ValidationsPattern;
 
 validations.items = { $each: validations };
 
@@ -42,11 +48,7 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model extends mix<Data, typeof DataModel>(
-  DataModel,
-  mixRollback(),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
-) {
+export class Model extends mix<Data, DataModel, typeof DataModel>(DataModel, mixRollback(), mixValidate(validations)) {
   constructor(initialData?: Data, react = true) {
     super('name', initialData ?? { name: '', items: [] }, react);
   }

--- a/packages/mix-models/tests/__mocks__/simple-invalid-model.ts
+++ b/packages/mix-models/tests/__mocks__/simple-invalid-model.ts
@@ -10,7 +10,7 @@ export type ModelType = Base<Data> & Validate;
 
 export interface Model extends DataModel, ValidatePrivate {}
 
-export class Model extends mix<Data, typeof DataModel>(DataModel, mixValidate((42 as unknown) as Pattern)) {
+export class Model extends mix<Data, DataModel, typeof DataModel>(DataModel, mixValidate((42 as unknown) as Pattern)) {
   constructor(initialData?: Data, react = true) {
     super('', initialData ?? { name: '' }, react);
   }

--- a/packages/mix-models/tests/__mocks__/simple-model.ts
+++ b/packages/mix-models/tests/__mocks__/simple-model.ts
@@ -12,7 +12,8 @@ import {
   ValidationBase,
   mix,
   Options,
-  ValidateOptions
+  ValidateOptions,
+  PatternAssert
 } from '@vueent/mix-models';
 
 export interface Data {
@@ -21,13 +22,9 @@ export interface Data {
 
 export const validations = {
   name: (v: any) => ((v as string).length > 0 && (v as string).length < 255 ? true : 'Unexpected name length')
-};
+} as const;
 
-export interface Validations extends ValidationBase {
-  readonly c: {
-    name: ValidationBase;
-  };
-}
+export type Validations = PatternAssert<typeof validations, Data>;
 
 export class DataModel extends BaseModel<Data> {}
 
@@ -35,10 +32,10 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model<ModelOptions extends Options> extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(
+export class Model<ModelOptions extends Options> extends mix<Data, DataModel, typeof DataModel>(
   DataModel,
   mixRollback(),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
+  mixValidate(validations)
 ) {
   constructor(initialData?: Data | Ref<Data>, react = true, ...options: ModelOptions[]) {
     super('name', initialData ?? { name: '' }, react, ...options);

--- a/packages/mix-models/tests/__mocks__/simple-no-pattern-model.ts
+++ b/packages/mix-models/tests/__mocks__/simple-no-pattern-model.ts
@@ -20,7 +20,7 @@ export type ModelType = Base<Data> & Validate;
 
 export interface Model<ModelOptions extends Options> extends DataModel, ValidatePrivate {}
 
-export class Model<ModelOptions extends Options> extends mix<Data, typeof DataModel>(DataModel, mixValidate()) {
+export class Model<ModelOptions extends Options> extends mix<Data, DataModel, typeof DataModel>(DataModel, mixValidate()) {
   constructor(initialData?: Data, react = true, ...options: ModelOptions[]) {
     super('', initialData ?? { name: '' }, react, ...options);
   }

--- a/packages/mix-models/tests/__mocks__/wrapper-model.ts
+++ b/packages/mix-models/tests/__mocks__/wrapper-model.ts
@@ -22,7 +22,7 @@ export const validations = {
   child: {
     $sub: childValidations
   }
-};
+} as const;
 
 export interface Validations extends ValidationBase {
   readonly c: {
@@ -36,11 +36,7 @@ export type ModelType = Base<Data> & Rollback & Validate<Validations>;
 
 export interface Model extends DataModel, RollbackPrivate<Data>, ValidatePrivate<Validations> {}
 
-export class Model extends mix<Data, typeof DataModel>(
-  DataModel,
-  mixRollback(),
-  mixValidate<Data, typeof DataModel, Validations>(validations)
-) {
+export class Model extends mix<Data, DataModel, typeof DataModel>(DataModel, mixRollback(), mixValidate(validations)) {
   constructor(initialData?: Data, react = true) {
     super('id', initialData ?? { id: 0, child: { name: '' } }, react);
   }

--- a/packages/mix-models/tests/validate/hard-model.test.ts
+++ b/packages/mix-models/tests/validate/hard-model.test.ts
@@ -14,11 +14,15 @@ function makeHardModel() {
 test('Validation should work with deep objects', () => {
   const instance = makeHardModel();
 
+  instance.v.c.documents.c[0]?.c.filename.dirty;
+
+  instance.v.c.phone.dirty;
+
   expect(instance.v.dirty).toBe(false);
   expect(instance.v.c.id.dirty).toBe(false);
-  expect(instance.v.c.credentials.c.first.dirty).toBe(false);
-  expect(instance.v.c.documents.c[0].c.filename.dirty).toBe(false);
-  expect(instance.v.c.phones.c[0].dirty).toBe(false);
+  expect(instance.v.c.credentials.c.first).toBe(false);
+  expect(instance.v.c.documents.c[0]?.c.filename.dirty).toBe(false);
+  expect(instance.v.c.phones.c[0]?.dirty).toBe(false);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.dirty).toBe(false);
 
   instance.v.touch();
@@ -26,8 +30,8 @@ test('Validation should work with deep objects', () => {
   expect(instance.v.dirty).toBe(true);
   expect(instance.v.c.id.dirty).toBe(true);
   expect(instance.v.c.credentials.c.first.dirty).toBe(true);
-  expect(instance.v.c.documents.c[0].c.filename.dirty).toBe(true);
-  expect(instance.v.c.phones.c[0].dirty).toBe(true);
+  expect(instance.v.c.documents.c[0]?.c.filename.dirty).toBe(true);
+  expect(instance.v.c.phones?.c[0]?.dirty).toBe(true);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.dirty).toBe(true);
 
   instance.data.items[0].value[0].val = '';

--- a/packages/mix-models/tests/validate/hard-model.test.ts
+++ b/packages/mix-models/tests/validate/hard-model.test.ts
@@ -1,5 +1,5 @@
 import { create as createHardModel, Validations as HardValidations } from '../__mocks__/hard-model';
-import { create as createCredentialModel, Validations as CredentialValidations } from '../__mocks__/credentials-model';
+import { /*create as createCredentialModel,*/ Validations as CredentialValidations } from '../__mocks__/credentials-model';
 
 import '../__mocks__/vue-vm';
 
@@ -16,7 +16,7 @@ function makeHardModel() {
 test('Validation should work with deep objects', () => {
   const instance = makeHardModel();
 
-  const sInstance = createCredentialModel({ first: 'Dan', second: 'Vasilev', last: 'Grigoryevich' });
+  // const sInstance = createCredentialModel({ first: 'Dan', second: 'Vasilev', last: 'Grigoryevich' });
 
   const hV: HardValidations = instance.v;
 

--- a/packages/mix-models/tests/validate/hard-model.test.ts
+++ b/packages/mix-models/tests/validate/hard-model.test.ts
@@ -1,10 +1,12 @@
-import { create as createHardModel } from '../__mocks__/hard-model';
+import { create as createHardModel, Validations as HardValidations } from '../__mocks__/hard-model';
+import { create as createCredentialModel, Validations as CredentialValidations } from '../__mocks__/credentials-model';
+
 import '../__mocks__/vue-vm';
 
 function makeHardModel() {
   return createHardModel({
     id: '',
-    credentials: { first: 'Dan', second: 'Borisov', last: 'Grigorevich' },
+    credentials: { first: 'Dan', second: 'Vasilev', last: 'Grigoryevich' },
     phones: ['123456789'],
     documents: [{ id: '1', filename: '1.pdf' }],
     items: [{ value: [{ val: 'large test' }] }]
@@ -13,6 +15,16 @@ function makeHardModel() {
 
 test('Validation should work with deep objects', () => {
   const instance = makeHardModel();
+
+  const sInstance = createCredentialModel({ first: 'Dan', second: 'Vasilev', last: 'Grigoryevich' });
+
+  const hV: HardValidations = instance.v;
+
+  const cV: CredentialValidations = hV.c.credentials;
+
+  //When field credentials in hard model is't undefined where is no error
+
+  hV.c.credentials = cV;
 
   instance.v.c.documents.c[0]?.c.filename.dirty;
 
@@ -45,8 +57,8 @@ test('Validation should work with deep objects', () => {
   expect(instance.v.dirty).toBe(false);
   expect(instance.v.c.id.dirty).toBe(false);
   expect(instance.v.c.credentials.c.first.dirty).toBe(false);
-  expect(instance.v.c.documents.c[0].c.filename.dirty).toBe(false);
-  expect(instance.v.c.phones.c[0].dirty).toBe(false);
+  expect(instance.v.c.documents.c[0]?.c.filename.dirty).toBe(false);
+  expect(instance.v.c.phones.c[0]?.dirty).toBe(false);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.dirty).toBe(false);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.invalid).toBe(false);
 });
@@ -80,5 +92,5 @@ test('Validation should work then we rollback model with undefined field', () =>
 
   instance.v.touch();
 
-  expect(instance.v.c.phones.c[0].dirty).toBe(true);
+  expect(instance.v.c.phones.c[0]?.dirty).toBe(true);
 });

--- a/packages/mix-models/tests/validate/hard-model.test.ts
+++ b/packages/mix-models/tests/validate/hard-model.test.ts
@@ -14,11 +14,13 @@ function makeHardModel() {
 test('Validation should work with deep objects', () => {
   const instance = makeHardModel();
 
+  instance.v.c.documents.c[0].c.filename;
+
   expect(instance.v.dirty).toBe(false);
   expect(instance.v.c.id.dirty).toBe(false);
   expect(instance.v.c.credentials.c.first.dirty).toBe(false);
   expect(instance.v.c.documents.c[0].c.filename.dirty).toBe(false);
-  expect(instance.v.c.phones.c[0].dirty).toBe(false);
+  expect(instance.v.c.phones?.c[0].dirty).toBe(false);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.dirty).toBe(false);
 
   instance.v.touch();
@@ -27,7 +29,7 @@ test('Validation should work with deep objects', () => {
   expect(instance.v.c.id.dirty).toBe(true);
   expect(instance.v.c.credentials.c.first.dirty).toBe(true);
   expect(instance.v.c.documents.c[0].c.filename.dirty).toBe(true);
-  expect(instance.v.c.phones.c[0].dirty).toBe(true);
+  expect(instance.v.c.phones?.c[0].dirty).toBe(true);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.dirty).toBe(true);
 
   instance.data.items[0].value[0].val = '';

--- a/packages/mix-models/tests/validate/hard-model.test.ts
+++ b/packages/mix-models/tests/validate/hard-model.test.ts
@@ -32,7 +32,7 @@ test('Validation should work with deep objects', () => {
 
   expect(instance.v.dirty).toBe(false);
   expect(instance.v.c.id.dirty).toBe(false);
-  expect(instance.v.c.credentials.c.first).toBe(false);
+  expect(instance.v.c.credentials.c.first.dirty).toBe(false);
   expect(instance.v.c.documents.c[0]?.c.filename.dirty).toBe(false);
   expect(instance.v.c.phones.c[0]?.dirty).toBe(false);
   expect(instance.v.c.items.c[0].c.value.c[0].c.val.dirty).toBe(false);

--- a/packages/mix-models/tests/validate/invalid-pattern.test.ts
+++ b/packages/mix-models/tests/validate/invalid-pattern.test.ts
@@ -1,4 +1,4 @@
-import { mixValidate, Pattern, mix } from '@vueent/mix-models';
+import { validateMixin, Pattern } from '@vueent/mix-models';
 
 import { Data, DataModel } from '../__mocks__/recursive-model';
 import { create as createSimpleInvalidModel } from '../__mocks__/simple-invalid-model';
@@ -30,10 +30,10 @@ test("validate mixin should throw an error if pattern's format is unsupported", 
 });
 
 test('validate mixin should throw an error when the format of some validation rule is not supported', () => {
-  class Model extends mix<Data, typeof DataModel>(
-    DataModel,
-    mixValidate(({ name: () => true, items: 42 } as unknown) as Pattern)
-  ) {
+  class Model extends validateMixin<Data, DataModel, typeof DataModel>(DataModel, ({
+    name: () => true,
+    items: 42
+  } as unknown) as Pattern) {
     constructor() {
       super('', { name: '', items: [] });
     }
@@ -99,7 +99,7 @@ test('pattern checker should break the chain when the $each argument is already 
   ];
 
   patterns.forEach(validations => {
-    class Model extends mix<Data, typeof DataModel>(DataModel, mixValidate(validations)) {}
+    class Model extends validateMixin<Data, DataModel, typeof DataModel>(DataModel, validations) {}
 
     let error;
 


### PR DESCRIPTION
Closes #19 

Automatic inference of model classes types won't work, because TypeScript doesn't support `typeof genericFunc<ConstraintT>`.
But automatic type inference of validations works perfect.